### PR TITLE
Dynamic Asset Count per row

### DIFF
--- a/src/WSAssetTableViewController.m
+++ b/src/WSAssetTableViewController.m
@@ -22,8 +22,7 @@
 #import "WSAssetsTableViewCell.h"
 #import "WSAssetWrapper.h"
 
-#define ASSETS_PER_ROW_PORTRAIT 4
-#define ASSETS_PER_ROW_LANDSCAPE 6
+#define ASSET_WIDTH_WITH_PADDING 79.0f
 
 @interface WSAssetTableViewController () <WSAssetsTableViewCellDelegate>
 @property (nonatomic, strong) NSMutableArray *fetchedAssets;
@@ -103,13 +102,7 @@
 
 - (NSInteger)assetsPerRow
 {
-    if (self.interfaceOrientation == UIInterfaceOrientationLandscapeLeft || 
-        self.interfaceOrientation == UIInterfaceOrientationLandscapeRight) {
-        
-        return ASSETS_PER_ROW_LANDSCAPE;
-    } else {
-        return ASSETS_PER_ROW_PORTRAIT;
-    }
+    return MAX(1, (NSInteger)floorf(self.tableView.contentSize.width / ASSET_WIDTH_WITH_PADDING));
 }
 
 #pragma mark - Rotation


### PR DESCRIPTION
Updated so that the number of assets per row is generated dynamically depending on the size of the tableview. This fixes issues with unused whitespace when picking images on iPhone 5 in Landscape.
