### PR TITLE
Controlling the order of assets within albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ WSAssetPickerController *controller = [[WSAssetPickerController alloc] initWithA
 [self presentViewController:controller animated:YES completion:NULL];
 ````
 
+To control the order of assets within the album, use ascendingOrder property.
+```` objective-c
+// This will list assets in an ascending order in the same way as Photos app does. The
+// view is scrolled to the bottom of the table.
+controller.ascendingOrder = YES;
+
+// This will list assets in descending order. The view stays at the top of the table.
+controller.ascendingOrder = YES;
+````
+
+
 #### Delegate Methods
 ```` objective-c
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To control the order of assets within the album, use ascendingOrder property.
 controller.ascendingOrder = YES;
 
 // This will list assets in descending order. The view stays at the top of the table.
-controller.ascendingOrder = YES;
+controller.ascendingOrder = NO;
 ````
 
 

--- a/demo/WSMainViewController.m
+++ b/demo/WSMainViewController.m
@@ -96,6 +96,7 @@
     
     WSAssetPickerController *picker = [[WSAssetPickerController alloc] initWithAssetsLibrary:library];
     picker.delegate = self;
+//    picker.ascendingOrder = YES;
     if ([sender isEqual:self.limitedPickButton])
         picker.selectionLimit = 5;
     

--- a/src/WSAssetPickerController.h
+++ b/src/WSAssetPickerController.h
@@ -43,6 +43,11 @@
 @property (nonatomic, readwrite) NSInteger selectionLimit;
 
 /** 
+ Specifies whether assets in albums should be displayed in an ascending order, similarly to the
+ default Photo's gallery */
+@property (nonatomic, readwrite) BOOL ascendingOrder;
+
+/** 
  Initializes an instance of `assetPickerViewController`.
  
  @param assetsLibrary An instance of `ALAssetsLibrary` for the picker to access media for selection __required__.

--- a/src/WSAssetPickerController.m
+++ b/src/WSAssetPickerController.m
@@ -83,6 +83,16 @@
     }
 }
 
+- (void)setAscendingOrder:(BOOL)ascendingOrder
+{
+    if (_ascendingOrder != ascendingOrder)
+    {
+        _ascendingOrder = ascendingOrder;
+        
+        self.assetPickerState.ascendingOrder = _ascendingOrder;
+    }
+}
+
 - (NSArray *)selectedAssets
 {
     return self.assetPickerState.selectedAssets;

--- a/src/WSAssetPickerState.h
+++ b/src/WSAssetPickerState.h
@@ -35,6 +35,7 @@ typedef enum {
 @property (nonatomic, readwrite) NSUInteger selectedCount;
 @property (nonatomic, readwrite) NSInteger selectionLimit;
 @property (nonatomic, readwrite) WSAssetPickingState state;
+@property (nonatomic, readwrite) BOOL ascendingOrder;
 
 - (void)changeSelectionState:(BOOL)selected forAsset:(ALAsset *)asset;
 

--- a/src/WSAssetPickerState.m
+++ b/src/WSAssetPickerState.m
@@ -29,6 +29,7 @@
 @synthesize selectedAssetsSet = _selectedAssetsSet;
 @synthesize selectedCount = _selectedCount;
 @synthesize state = _state;
+@synthesize ascendingOrder = _ascendingOrder;
 
 - (id)init
 {

--- a/src/WSAssetTableViewController.m
+++ b/src/WSAssetTableViewController.m
@@ -132,6 +132,16 @@
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self.tableView reloadData];
+
+                    if (self.assetPickerState.ascendingOrder)
+                    {
+                        // Scroll to the bottom of the table is the sort should be ascending.
+                        if (self.fetchedAssets.count > 0)
+                        {
+                            int nRows = (self.fetchedAssets.count - 1) / self.assetsPerRow;
+                            [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:nRows inSection:0] atScrollPosition:UITableViewScrollPositionBottom animated:NO];
+                        }
+                    }
                     self.navigationItem.title = [NSString stringWithFormat:@"%@", [self.assetsGroup valueForProperty:ALAssetsGroupPropertyName]];
                 });
                 
@@ -141,8 +151,14 @@
             WSAssetWrapper *assetWrapper = [[WSAssetWrapper alloc] initWithAsset:result];
             
             dispatch_async(dispatch_get_main_queue(), ^{
-                
-                [self.fetchedAssets addObject:assetWrapper];
+                if (self.assetPickerState.ascendingOrder)
+                {
+                    [self.fetchedAssets insertObject:assetWrapper atIndex:0];
+                }
+                else
+                {
+                    [self.fetchedAssets addObject:assetWrapper];
+                }
                 
             });
             


### PR DESCRIPTION
Adds support for controlling the order of assets in albums to reflect the way assets are presented to the user in the Photos app.

Toggling is available using WSAssetPickerController property called ascendingOrder which is stored within the state.
