### PR TITLE
Adding delegate method to tell that we found access error to photos.

### DIFF
--- a/demo/WSMainViewController.m
+++ b/demo/WSMainViewController.m
@@ -123,7 +123,13 @@
 
 
 #pragma mark - WSAssetPickerControllerDelegate Methods
-
+- (void)assetPickerControllerFoundAccessError:(WSAssetPickerController *)sender{
+    NSString *title = [NSString stringWithFormat:@"%@ doesn't have access to your photos or videos.", @"This App"]; //replace with your app's name
+    NSString *message = @"You can enable access in Privacy Settings.";
+    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:message delegate:nil cancelButtonTitle:@"Okay" otherButtonTitles:nil];
+    
+    [alert show];
+}
 - (void)assetPickerControllerDidCancel:(WSAssetPickerController *)sender
 {
     [self dismissViewControllerAnimated:YES completion:NULL];

--- a/src/WSAlbumTableViewController.m
+++ b/src/WSAlbumTableViewController.m
@@ -88,7 +88,13 @@
         });
         
     } failureBlock:^(NSError *error) {
-        // TODO: User denied access. Tell them we can't do anything.
+        if (error.code == ALAssetsLibraryAccessUserDeniedError) {
+            [self.assetPickerState setState:WSAssetPickerStateAccessError];
+        }else{
+            //Generic error is being reported here.
+            [self.assetPickerState setState:WSAssetPickerStateError];
+        }
+        // TODO: handle any other error
     }];
 }
 

--- a/src/WSAssetPickerController.h
+++ b/src/WSAssetPickerController.h
@@ -99,4 +99,19 @@
  */
 - (void)assetPickerControllerDidLimitSelection:(WSAssetPickerController *)sender;
 
+/**
+ Tells the delegate that app does not access to photos.
+ 
+ @param sender The controller object managing the asset picker interface.
+ */
+- (void)assetPickerControllerFoundAccessError:(WSAssetPickerController *)sender;
+
+/**
+ Tells the delegate that the controller found an error.
+ 
+ @param sender The controller object managing the asset picker interface.
+ */
+- (void)assetPickerControllerFoundError:(WSAssetPickerController *)sender;
+
+
 @end

--- a/src/WSAssetPickerController.m
+++ b/src/WSAssetPickerController.m
@@ -156,6 +156,18 @@
                 [delegate assetPickerControllerDidLimitSelection:self];
             }
         }
+        else if (WSAssetPickerStateAccessError == self.assetPickerState.state) {
+            //tells the delegate that we found an access error
+            if ([delegate respondsToSelector:@selector(assetPickerControllerFoundAccessError:)]) {
+                [delegate assetPickerControllerFoundAccessError:self];
+            }
+        }
+        else if (WSAssetPickerStateError == self.assetPickerState.state) {
+            if ([delegate respondsToSelector:@selector(assetPickerControllerFoundError:)]) {
+                [delegate assetPickerControllerFoundError:self];
+            }
+        }
+
     } else if ([SELECTED_COUNT_KEY isEqualToString:keyPath]) {
         
         self.selectedCount = self.assetPickerState.selectedCount;

--- a/src/WSAssetPickerState.h
+++ b/src/WSAssetPickerState.h
@@ -26,7 +26,9 @@ typedef enum {
     WSAssetPickerStatePickingAssets,
     WSAssetPickerStateSelectionLimitReached,
     WSAssetPickerStatePickingDone,
-    WSAssetPickerStatePickingCancelled
+    WSAssetPickerStatePickingCancelled,
+    WSAssetPickerStateAccessError,
+    WSAssetPickerStateError
 } WSAssetPickingState;
 
 @interface WSAssetPickerState : NSObject


### PR DESCRIPTION
Hi,

I've added two more `WSAssetPickingState` to show error and deliver message to presenting controller about the error. 

When user doesn't allow app to access photos, `WSAlbumTableViewController` keeps showing `@"Loading…"`. So I've added `WSAssetPickerStateAccessError` to deliver message to delegate that it has meet `ALAssetsLibraryAccessUserDeniedError`. There's another generic error to cover other kind of errors.

![screenshot](https://cloud.githubusercontent.com/assets/856233/2946059/d988e160-d9e7-11e3-8be4-7900dfd1da40.png)
