### PR TITLE
Fix selected image when used in framework

### DIFF
--- a/src/WSAssetViewColumn.m
+++ b/src/WSAssetViewColumn.m
@@ -90,7 +90,8 @@
     if (!_selectedView) {
         
         // Lazily create the selectedView.
-        UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:SELECTED_IMAGE]];
+        NSBundle *bundle = [NSBundle bundleForClass:WSAssetViewColumn.class];
+        UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:SELECTED_IMAGE inBundle:bundle compatibleWithTraitCollection:nil]];
         imageView.hidden = YES;
         [self addSubview:imageView];
         


### PR DESCRIPTION
On (at least) iOS8, the image is not loaded correctly when WSAssetPickerController is a framework, causing no indicator to appear when an image is selected. This change searches for the image inside the framework.
