### PR TITLE
Fixed bug with positioning images

### DIFF
--- a/src/WSAssetsTableViewCell.m
+++ b/src/WSAssetsTableViewCell.m
@@ -108,7 +108,7 @@
 - (void)layoutSubviews
 {
     // Calculate the container's width.
-    int assetsPerRow = self.frame.size.width / ASSET_VIEW_FRAME.size.width;    
+    int assetsPerRow = (self.frame.size.width + ASSET_VIEW_PADDING) / (ASSET_VIEW_FRAME.size.width+ASSET_VIEW_PADDING);    
     float containerWidth = assetsPerRow * ASSET_VIEW_FRAME.size.width + (assetsPerRow - 1) * ASSET_VIEW_PADDING;
     
     // Create the container frame dynamically.


### PR DESCRIPTION
Fixed a bug with calculation of assetsPerRow. Original calculation didi not take into account padding between assets. So in rare cases containerWidth became larger then self.frame.size.width and images was shifted to negative x origin.
